### PR TITLE
fix: no more template for empty line

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ fs.readFile('.env', 'utf8', (err, data) => {
   data = data.split('\n');
   data = data.forEach((element) => {
     let key = element.split('=')[0];
-    tempData.push(key.concat(`=#Your ${key} here\n`));
+    if (key.length != 0) {
+      tempData.push(key.concat(`=#Your ${key} here\n`));
+    }
   });
   tempData.forEach((element) => {
     tempEnv = `${tempEnv}${element}`;


### PR DESCRIPTION
I've added a check in order to prevent a wrong behavior when a line is empty or when the key is missing.

In the previous version of the code, an empty line would result in the creation of a template value with no corresponding key, which could cause issues like this:
`=#Your  here`

With this fix, the script will only create template values for lines that contain a valid key-value pair. Any empty lines in the input file will be ignored, ensuring that the output file does not contain any extraneous or incorrect values.